### PR TITLE
fixed an error while saving non-utf8 followers output

### DIFF
--- a/src/Osintgram.py
+++ b/src/Osintgram.py
@@ -311,9 +311,9 @@ class Osintgram:
 
         if self.writeFile:
             file_name = "output/" + self.target + "_followers.txt"
-            file = open(file_name, "w")
-            file.write(str(t))
-            file.close()
+            with open(file_name, 'w', encoding='utf-8') as f:
+                f.write(str(t))
+                f.close()
 
         if self.jsonDump:
             json_data['followers'] = followers


### PR DESCRIPTION
while FILE=y when saving a non-utf8 language an error will be thrown.
file.write() python UnicodeEncodeError: 'charmap' codec can't encode characters
this commit fixes this issue at line 315