### PR TITLE
Ensure post location has lat,lng before trying to process

### DIFF
--- a/src/Osintgram.py
+++ b/src/Osintgram.py
@@ -126,9 +126,10 @@ class Osintgram:
 
         for post in data:
             if 'location' in post and post['location'] is not None:
-                lat = post['location']['lat']
-                lng = post['location']['lng']
-                locations[str(lat) + ', ' + str(lng)] = post.get('taken_at')
+                if 'lat' in post['location'] and 'lng' in post['location']:
+                    lat = post['location']['lat']
+                    lng = post['location']['lng']
+                    locations[str(lat) + ', ' + str(lng)] = post.get('taken_at')
 
         address = {}
         for k, v in locations.items():


### PR DESCRIPTION
I found that sometimes posts do not have a lat and lng so a `KeyError` is thrown.  This PR just ensures the post's location property has these properties before trying to process.