### PR TITLE
Fix the env, and readline

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Osintgram offers an interactive shell to perform analysis on Instagram account o
 ```
 You can find detailed commands usage [here](doc/COMMANDS.md).
 
-[**Latest version**](https://github.com/Datalux/Osintgram/releases/tag/1.0) | 
+[**Latest version**](https://github.com/Datalux/Osintgram/releases/tag/1.0.1) | 
 [CHANGELOG](doc/CHANGELOG.md)
 
 ## Tools

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.1](https://github.com/Datalux/Osintgram/releases/tag/1.0.1)
+**Bug fixes**
+- Set itself as target by param
+
 ## [1.0](https://github.com/Datalux/Osintgram/releases/tag/1.0)
 **Enhancements**
 - Set itself as target (#53)

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ def printlogo():
     pc.printout("\_______  /____  >__|___|  /__| \___  /|__|  (____  /__|_|  /\n", pc.YELLOW)
     pc.printout("        \/     \/        \/    /_____/            \/      \/ \n", pc.YELLOW)
     print('\n')
-    pc.printout("Version 1.0 - Developed by Giuseppe Criscione\n\n", pc.YELLOW)
+    pc.printout("Version 1.0.1 - Developed by Giuseppe Criscione\n\n", pc.YELLOW)
     pc.printout("Type 'list' to show all allowed commands\n")
     pc.printout("Type 'FILE=y' to save results to files like '<target username>_<command>.txt (deafult is disabled)'\n")
     pc.printout("Type 'FILE=n' to disable saving to files'\n")

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 from src.Osintgram import Osintgram
@@ -6,7 +6,7 @@ import argparse
 from src import printcolors as pc
 import sys
 import signal
-import readline
+import gnureadline
 
 commands = ["quit", "exit", "list", "help", "addrs", "captions", "comments", "followers",
             "followings", "fwersemail", "fwingsemail", "hashtags", "info", "likes",
@@ -90,8 +90,8 @@ def completer(text, state):
 
 
 signal.signal(signal.SIGINT, signal_handler)
-readline.parse_and_bind("tab: complete")
-readline.set_completer(completer)
+gnureadline.parse_and_bind("tab: complete")
+gnureadline.set_completer(completer)
 
 printlogo()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ requests-toolbelt==0.9.1
 geopy>=2.0.0
 prettytable==0.7.2
 instagram-private-api==1.6.0
-readline>=6.2.4
+gnureadline>=8.0.0


### PR DESCRIPTION
According to the PyPI page of readline, readline is deprecated, and to use gnureadline.
Also, I am not sure about others. But in my experience, when using a version of python 3 or above, the executables are named python3, and so therefore the shebang should point to python3 and not python (as this was pointing to python2.7 for me)