### PR TITLE
Included venv instructions and added venv/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 output/
 *.pyc
 *.json
+venv/

--- a/README.md
+++ b/README.md
@@ -52,20 +52,27 @@ You can find detailed commands usage [here](doc/COMMANDS.md).
 
     `cd Osintgram`
 
-3. Run `pip3 install -r requirements.txt`
+3. Create a virtual environment for this project
 
+    `python3 -m venv venv`
 
-4. Create a subdirectory `config`
+4. Load the virtual environment
+   - On Windows Powershell: `.\venv\Scripts\activate.ps1`
+   - On Linux and Git Bash: `source venv/bin/activate`
+  
+5.  Run `pip install -r requirements.txt`
+
+6. Create a subdirectory `config`
 
     `mkdir config`
 
-5. Create in `config` folder the file: `username.conf` and write your Instagram account username
+7. Create in `config` folder the file: `username.conf` and write your Instagram account username
 
-6. Create in `config` folder the file: `pw.conf` and write your Instagram account password
+8. Create in `config` folder the file: `pw.conf` and write your Instagram account password
 
-7. Create in `config` folder the file: `settings.json` and write the following string: "{}" without quotation marks
+9.  Create in `config` folder the file: `settings.json` and write the following string: "{}" without quotation marks
 
-8. Run the main.py script 
+10. Run the main.py script 
 
     `python3 main.py <target username>`
     


### PR DESCRIPTION
By default, running `pip3 install -r requirements.txt` outside of a virtual environment will install packages for the entire system. This is bad, since different projects may require conflicting versions of the same packages. The best practice is to use some kind of virtual environment (this feature typically comes preinstalled with most distributions, so all you really need to do is run a simple command to set it up) and install the packages inside that venv.

This also makes it much easier to contribute for anyone who's already familiar with using a venv.

Note that this PR will create a merge conflict with #125 because they both change the contents of the README.md file. I suggest merging this PR first, and then I'll rebase and force-push my config branch for the other PR - that way all you'll need to do is just merge them both.