### PR TITLE
[FEATURE] Add possibility to download comments

### DIFF
--- a/doc/COMMANDS.md
+++ b/doc/COMMANDS.md
@@ -2,6 +2,7 @@
 ```
 - addrs           Get all registered addressed by target photos
 - captions        Get user's photos captions
+- commentdata     Get a list of all the comments on the target's posts
 - comments        Get total comments of target's posts
 - followers       Get target followers
 - followings      Get users followed by target

--- a/main.py
+++ b/main.py
@@ -146,7 +146,8 @@ commands = {
     'tagged':           api.get_people_tagged_by_user,
     'target':           api.change_target,
     'wcommented':       api.get_people_who_commented,
-    'wtagged':          api.get_people_who_tagged
+    'wtagged':          api.get_people_who_tagged, 
+    "commentdata":      api.get_comment_data
 }
 
 signal.signal(signal.SIGINT, signal_handler)

--- a/main.py
+++ b/main.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 from src.Osintgram import Osintgram
 import argparse
@@ -18,11 +17,11 @@ except:
 
 def printlogo():
     pc.printout("________         .__        __                               \n", pc.YELLOW)
-    pc.printout("\_____  \   _____|__| _____/  |_  ________________    _____  \n", pc.YELLOW)
-    pc.printout(" /   |   \ /  ___/  |/    \   __\/ ___\_  __ \__  \  /     \ \n", pc.YELLOW)
-    pc.printout("/    |    \\\___ \|  |   |  \  | / /_/  >  | \// __ \|  Y Y  \\\n", pc.YELLOW)
-    pc.printout("\_______  /____  >__|___|  /__| \___  /|__|  (____  /__|_|  /\n", pc.YELLOW)
-    pc.printout("        \/     \/        \/    /_____/            \/      \/ \n", pc.YELLOW)
+    pc.printout("\\_____  \\   _____|__| _____/  |_  ________________    _____  \n", pc.YELLOW)
+    pc.printout(" /   |   \\ /  ___/  |/    \\   __\\/ ___\\_  __ \\__  \\  /     \\ \n", pc.YELLOW)
+    pc.printout("/    |    \\\\___ \\|  |   |  \\  | / /_/  >  | \\// __ \\|  Y Y  \\\n", pc.YELLOW)
+    pc.printout("\\_______  /____  >__|___|  /__| \\___  /|__|  (____  /__|_|  /\n", pc.YELLOW)
+    pc.printout("        \\/     \\/        \\/    /_____/            \\/      \\/ \n", pc.YELLOW)
     print('\n')
     pc.printout("Version 1.1 - Developed by Giuseppe Criscione\n\n", pc.YELLOW)
     pc.printout("Type 'list' to show all allowed commands\n")
@@ -42,6 +41,8 @@ def cmdlist():
     print("Get all registered addressed by target photos")
     pc.printout("captions\t")
     print("Get target's photos captions")
+    pc.printout("commentdata\t")
+    print("Get a list of all the comments on the target's posts")
     pc.printout("comments\t")
     print("Get total comments of target's posts")
     pc.printout("followers\t")
@@ -128,6 +129,7 @@ commands = {
     'exit':             _quit,
     'addrs':            api.get_addrs,
     'captions':         api.get_captions,
+    "commentdata":      api.get_comment_data,
     'comments':         api.get_total_comments,
     'followers':        api.get_followers,
     'followings':       api.get_followings,
@@ -146,8 +148,7 @@ commands = {
     'tagged':           api.get_people_tagged_by_user,
     'target':           api.change_target,
     'wcommented':       api.get_people_who_commented,
-    'wtagged':          api.get_people_who_tagged, 
-    "commentdata":      api.get_comment_data
+    'wtagged':          api.get_people_who_tagged
 }
 
 signal.signal(signal.SIGINT, signal_handler)

--- a/src/Osintgram.py
+++ b/src/Osintgram.py
@@ -47,7 +47,7 @@ class Osintgram:
 
     def __getUsername__(self):
         try:
-            u = open("config/username.conf", "r").read()
+            u = open("config/username.conf").read()
             u = u.replace("\n", "")
             return u
         except FileNotFoundError:
@@ -57,7 +57,7 @@ class Osintgram:
 
     def __getPassword__(self):
         try:
-            p = open("config/pw.conf", "r").read()
+            p = open("config/pw.conf").read()
             p = p.replace("\n", "")
             return p
         except FileNotFoundError:
@@ -1108,7 +1108,7 @@ class Osintgram:
             settings_file = "config/settings.json"
             if not os.path.isfile(settings_file):
                 # settings file does not exist
-                print('Unable to find file: {0!s}'.format(settings_file))
+                print(f'Unable to find file: {settings_file!s}')
 
                 # login new
                 self.api = AppClient(auto_patch=True, authenticate=True, username=u, password=p,
@@ -1126,7 +1126,7 @@ class Osintgram:
                     on_login=lambda x: self.onlogin_callback(x, settings_file))
 
         except (ClientCookieExpiredError, ClientLoginRequiredError) as e:
-            print('ClientCookieExpiredError/ClientLoginRequiredError: {0!s}'.format(e))
+            print(f'ClientCookieExpiredError/ClientLoginRequiredError: {e!s}')
 
             # Login expired
             # Do relogin but use default ua, keys and such

--- a/src/Osintgram.py
+++ b/src/Osintgram.py
@@ -47,7 +47,7 @@ class Osintgram:
 
     def __getUsername__(self):
         try:
-            u = open("config/username.conf").read()
+            u = open("config/username.conf", "r").read()
             u = u.replace("\n", "")
             return u
         except FileNotFoundError:
@@ -57,7 +57,7 @@ class Osintgram:
 
     def __getPassword__(self):
         try:
-            p = open("config/pw.conf").read()
+            p = open("config/pw.conf", "r").read()
             p = p.replace("\n", "")
             return p
         except FileNotFoundError:

--- a/src/Osintgram.py
+++ b/src/Osintgram.py
@@ -271,6 +271,57 @@ class Osintgram:
 
         pc.printout(str(comments_counter), pc.MAGENTA)
         pc.printout(" comments in " + str(posts) + " posts\n")
+        
+    def get_comment_data(self):
+        if self.check_private_profile():
+            return
+
+        pc.printout("Retrieving all comments, this may take a moment...\n")
+        data = self.__get_feed__()
+        
+        _comments = []
+        t = PrettyTable(['POST ID', 'ID', 'Username', 'Comment'])
+        t.align["POST ID"] = "l"
+        t.align["ID"] = "l"
+        t.align["Username"] = "l"
+        t.align["Comment"] = "l"
+
+        for post in data:
+            post_id = post.get('id')
+            comments = self.api.media_n_comments(post_id)
+            for comment in comments:
+                t.add_row([post_id, comment.get('user_id'), comment.get('user').get('username'), comment.get('text')])
+                comment = {
+                        "post_id": post_id,
+                        "user_id":comment.get('user_id'), 
+                        "username": comment.get('user').get('username'),
+                        "comment": comment.get('text')
+                    }
+                _comments.append(comment)
+        
+        print(t)
+        if self.writeFile:
+            file_name = "output/" + self.target + "_comment_data.txt"
+            with open(file_name, 'w') as f:
+                f.write(str(t))
+        
+        if self.jsonDump:
+            file_name_json = "output/" + self.target + "_comment_data.json"
+            with open(file_name_json, 'w') as f:
+                f.write("{ \"Comments\":[ \n")
+                i = 0
+                for comment in _comments:
+                    json.dump(comment, f)
+                    
+                    i+= 1
+                    if i == len(_comments):
+                        f.write('\n')
+                    else:
+                        f.write(',\n')
+
+                f.write("]} ")
+                f.close()
+
 
     def get_followers(self):
         if self.check_private_profile():

--- a/src/Osintgram.py
+++ b/src/Osintgram.py
@@ -271,7 +271,7 @@ class Osintgram:
 
         pc.printout(str(comments_counter), pc.MAGENTA)
         pc.printout(" comments in " + str(posts) + " posts\n")
-        
+
     def get_comment_data(self):
         if self.check_private_profile():
             return
@@ -304,6 +304,7 @@ class Osintgram:
             file_name = "output/" + self.target + "_comment_data.txt"
             with open(file_name, 'w') as f:
                 f.write(str(t))
+                f.close()
         
         if self.jsonDump:
             file_name_json = "output/" + self.target + "_comment_data.json"


### PR DESCRIPTION
I have added the feature from issue #82 for users to download the comments from all posts on the existing target. The command-line name is `commentdata` as the function retrieves the data so I thought the name would be fitting. The function outputs a table with `prettytable` that displays the post id, user_id, the username, and comment associated with the post. I believed that adding the post_id would make sense so people could differentiate between the comments of each post. 
The function then if specified, outputs the table to either a JSON or txt file when FILE or JSON is enabled. 