### PR TITLE
Fixed SSL certificate error

### DIFF
--- a/src/Osintgram.py
+++ b/src/Osintgram.py
@@ -6,6 +6,8 @@ import os
 import codecs
 
 import requests
+import ssl
+ssl._create_default_https_context = ssl._create_unverified_context
 
 from geopy.geocoders import Nominatim
 from instagram_private_api import Client as AppClient


### PR DESCRIPTION
Fixes [this error](https://github.com/Datalux/Osintgram/issues/122#issuecomment-811800800).

Detailed error message can be obtained by adding
`pc.printout('ClientError {0!s} (Code: {1:d}, Response: {2!s})'.format(e.msg, e.code, e.error_response), pc.RED)`
to the `except` block of the `get_user` definition
on line 1001.

The message reads `ClientError URLError <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1076)> (Code: 0, Response: )`