### PR TITLE
Fix JSON fields for user info

### DIFF
--- a/src/Osintgram.py
+++ b/src/Osintgram.py
@@ -553,8 +553,8 @@ class Osintgram:
                     'biography': data['biography'],
                     'edge_followed_by': data['follower_count'],
                     'edge_follow': data['following_count'],
-                    'is_business_account': data['is_business_account'],
-                    'is_verified': data['is_business'],
+                    'is_business_account': data['is_business'],
+                    'is_verified': data['is_verified'],
                     'profile_pic_url_hd': data['hd_profile_pic_url_info']['url']
                 }
                 if 'public_email' in data and data['public_email']:


### PR DESCRIPTION
2 fields was not named correctly

is_business_account was not in the data definition, replaced by is_business
is_verified : is_business was used instead of is_verified
