### PR TITLE
Fix commentdata json output format

### DIFF
--- a/src/Osintgram.py
+++ b/src/Osintgram.py
@@ -307,7 +307,7 @@ class Osintgram:
             file_name_json = self.output_dir + "/" + self.target + "_comment_data.json"
             with open(file_name_json, 'w') as f:
                 f.write("{ \"Comments\":[ \n")
-                f.write('\n'.join(json.dumps(comment) for comment in _comments) + ',\n')
+                f.write(',\n'.join(json.dumps(comment) for comment in _comments) + '\n')
                 f.write("]} ")
 
 


### PR DESCRIPTION
Right now when writing json file on commentdata command, comments are not separated by comma, just by enter.

With this fix the output data is valid json format.


Replace  example:
```
{ "Comments":[
{"post_id": "", "user_id": "", "username": "", "comment": ""}
{"post_id": "", "user_id": "", "username": "", "comment": ""},
]}
```
with
```
{ "Comments":[
{"post_id": "", "user_id": "", "username": "", "comment": ""},
{"post_id": "", "user_id": "", "username": "", "comment": ""}
]}
```