### PR TITLE
Fix addrs command - Missing Details for given Lat-Lon

### DIFF
--- a/src/Osintgram.py
+++ b/src/Osintgram.py
@@ -131,6 +131,8 @@ class Osintgram:
         address = {}
         for k, v in locations.items():
             details = self.geolocator.reverse(k)
+            if not details:
+                continue
             unix_timestamp = datetime.datetime.fromtimestamp(v)
             address[details.address] = unix_timestamp.strftime('%Y-%m-%d %H:%M:%S')
 


### PR DESCRIPTION
`geopy`'s `reverse()` returns `None` for some Lat Lon values, this wasn't being handled gracefully in `Osintgram`. 
For example, if we get Lat Lon values as `89.06192, 4.53075`, `self.geolocator.reverse()` will return `None`.
This PR will skip the locations which do not have any addresses mapped to them.

Issue: https://github.com/Datalux/Osintgram/issues/503