### PR TITLE
[v2] Fix addrs command - Missing Details for given Lat-Lon

### DIFF
--- a/src/commands/address/run.py
+++ b/src/commands/address/run.py
@@ -53,6 +53,8 @@ class Command(CommandFather):
         address = {}
         for k, v in locations.items():
             details = self.osintgram.geolocator.reverse(k)
+            if not details:
+                continue
             unix_timestamp = dt.datetime.fromtimestamp(v)
             address[details.address] = unix_timestamp.strftime('%Y-%m-%d %H:%M:%S')
 


### PR DESCRIPTION
`geopy`'s `reverse()` returns `None` for some Lat Lon values, this wasn't being handled gracefully in `src/commands/address/run.py`.
For example, if we get Lat Lon values as `89.06192, 4.53075`, `self.osintgram.geolocator.reverse()` will return `None`.
This PR will skip the locations which do not have any addresses mapped to them.

Duplicated from `development` branch
Ref: https://github.com/Datalux/Osintgram/pull/518#issuecomment-1168874291
