### PR TITLE
Add heirarchy in output folder (based on target)

### DIFF
--- a/src/Osintgram.py
+++ b/src/Osintgram.py
@@ -61,6 +61,13 @@ class Osintgram:
         self.following = self.check_following()
         if(show_output):
             self.__printTargetBanner__()
+    
+    def create_target_output_directory(self):
+        # Create directory for target (if absent)
+        user_output_dir = self.output_dir + "/" + self.target
+        if not os.path.exists(user_output_dir):
+            os.mkdir(user_output_dir)
+        return user_output_dir
 
     def __get_feed__(self):
         data = []
@@ -883,6 +890,8 @@ class Osintgram:
             next_max_id = results.get('next_max_id')
 
         try:
+            target_output_directory = self.create_target_output_directory()
+
             for item in data:
                 if counter == limit:
                     break
@@ -890,7 +899,7 @@ class Osintgram:
                     counter = counter + 1
                     url = item["image_versions2"]["candidates"][0]["url"]
                     photo_id = item["id"]
-                    end = self.output_dir + "/" + self.target + "_" + photo_id + ".jpg"
+                    end = target_output_directory + "/" + photo_id + ".jpg"
                     urllib.request.urlretrieve(url, end)
                     sys.stdout.write("\rDownloaded %i" % counter)
                     sys.stdout.flush()
@@ -902,7 +911,7 @@ class Osintgram:
                         counter = counter + 1
                         url = i["image_versions2"]["candidates"][0]["url"]
                         photo_id = i["id"]
-                        end = self.output_dir + "/" + self.target + "_" + photo_id + ".jpg"
+                        end = target_output_directory + "/" + photo_id + ".jpg"
                         urllib.request.urlretrieve(url, end)
                         sys.stdout.write("\rDownloaded %i" % counter)
                         sys.stdout.flush()


### PR DESCRIPTION
Fixes https://github.com/Datalux/Osintgram/issues/537

This PR stores the output photos of the `photos` command, into separate folders in the output directory, based on the target username.
```
output
├── dont_delete_this_folder.txt
├── target_1
│   ├── 2661892880972654705_1552784059.jpg
│   └── 2690951453557838074_1552784059.jpg
└── target_2
    ├── 2879901569904497617_45635562290.jpg
    └── 2880124787004280963_45635562290.jpg

2 directories, 4 files
```
@Datalux 