### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ prettytable==0.7.2
 instagram-private-api==1.6.0
 gnureadline>=8.0.0; platform_system != "Windows"
 pyreadline==2.1; platform_system == "Windows"
+six>=1.15.0
+urllib3>=1.25.10


### PR DESCRIPTION
 The current requirements.txt file for the project does not include the six and urllib3 libraries, which are essential for the requests package to function correctly. This omission can lead to **Module Not Found Error** when attempting to import these modules during runtime, particularly when using versions of the requests library that depend on them.

`six>=1.15.0: `This ensures compatibility with both Python 2 and 3.
`urllib3>=1.25.10:` This ensures that the required version of urllib3 is installed, facilitating proper HTTP request handling.