### PR TITLE
Use pyreadline3 instead of pyreadline

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ try:
     import gnureadline  
 except: 
     is_windows = True
-    import pyreadline
+    import pyreadline3 as pyreadline
 
 
 def printlogo():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 requests==2.24.0
 requests-toolbelt==0.9.1
 geopy>=2.0.0
-prettytable==0.7.2
+prettytable
 instagram-private-api==1.6.0
 gnureadline>=8.0.0; platform_system != "Windows"
-pyreadline==2.1; platform_system == "Windows"
+pyreadline3==3.5.4; platform_system == "Windows"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 requests==2.24.0
 requests-toolbelt==0.9.1
 geopy>=2.0.0
-prettytable
+prettytable==0.7.2
 instagram-private-api==1.6.0
 gnureadline>=8.0.0; platform_system != "Windows"
 pyreadline3==3.5.4; platform_system == "Windows"


### PR DESCRIPTION
On newer versions of Python, [pyreadline doesnt work well](https://github.com/Datalux/Osintgram/issues/1176#issuecomment-2485423694). Using [pyreadline3](https://pypi.org/project/pyreadline3/) instead fixes that issue. 